### PR TITLE
Remove deleteUser assert

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -139,11 +139,6 @@ export default class Client {
       })
       .bind(this)
       .then(parseResponse)
-      .tap(response => {
-        assert(response, {
-          message: [is.required(), is.equalTo('User was added to remove.')]
-        });
-      })
       .asCallback(callback);
     });
   }

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -1792,34 +1792,6 @@ describe('Client', () => {
       }
     });
 
-    it('should throw an error if `response` is missing required fields', async () => {
-      nock(/authy/).post(/\//).reply(200, { success: true });
-
-      try {
-        await client.deleteUser({ authyId: 1635 });
-
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-
-        e.errors.message.show().assert.should.equal('HaveProperty');
-      }
-    });
-
-    it('should throw an error if `response` contains invalid fields', async () => {
-      nock(/authy/).post(/\//).reply(200, { message: 'foo', success: true });
-
-      try {
-        await client.deleteUser({ authyId: 1635 });
-
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-
-        e.errors.message[0].show().assert.should.equal('EqualTo');
-      }
-    });
-
     it('should accept the `ip` of the requester', async () => {
       mocks.deleteUser.succeed({ request: { body: { user_ip: '127.0.0.1' } } });
 


### PR DESCRIPTION
This removes a very specific assert on the exact format of the message. We found that this message have changed.

I do not think it is reasonable to expect an API to have unchangeable wording of messages.