### PR TITLE
Loosen host check

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Note that all calls must be authenticated using the API Key. However, if you pre
 1. `args` _(Object)_: the required arguments object.
 2. `args.key` _(string)_: The private API key obtained from the [Authy Dashboard](https://dashboard.authy.com/).
 3. `[options]` _(Object)_: The options object.
-4. `[options.host=https://api.authy.com]` _(string)_: The target endpoint (`https://api.authy.com` or `https://sandbox-api.authy.com`).
+4. `[options.host=https://api.authy.com]` _(string)_: The target API endpoint.
 5. `[options.timeout=5000]` _(number)_: The maximum request time, in milliseconds.
 
 ##### Example

--- a/src/client.js
+++ b/src/client.js
@@ -43,7 +43,7 @@ function source(...args) {
 export default class Client {
   constructor({ key } = {}, { host = 'https://api.authy.com', timeout = 5000 } = {}) {
     validate({ host, key, timeout }, {
-      host: [is.string(), is.choice(['https://api.authy.com', 'https://sandbox-api.authy.com'])],
+      host: is.string(),
       key: [is.required(), is.notBlank()],
       timeout: [is.integer(), is.greaterThanOrEqual(0)]
     });

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -45,13 +45,12 @@ describe('Client', () => {
 
     it('should throw an error if `host` is invalid', () => {
       try {
-        new Client({ key: 'foo' }, { host: 'https://foo.bar' });
+        new Client({ key: 'foo' }, { host: 123 });
 
         should.fail();
       } catch (e) {
         e.should.be.instanceOf(ValidationFailedError);
-        e.errors.host[0].show().assert.should.equal('Choice');
-        e.errors.host[0].show().violation.choices.should.eql(['https://api.authy.com', 'https://sandbox-api.authy.com']);
+        e.errors.host[0].show().assert.should.equal('IsString');
       }
     });
 


### PR DESCRIPTION
The sandbox API is getting deprecated sometime in the future so pointing the client to a mock server is something developers will have to do if they need to simulate API responses.

Refs https://github.com/ruimarinho/authy-client/issues/34.