### PR TITLE
Add fail verify token mock

### DIFF
--- a/test/mocks/verify-token-mock.js
+++ b/test/mocks/verify-token-mock.js
@@ -18,6 +18,25 @@ function mock({ request = {}, response = {} }) {
 }
 
 /**
+ * Export a request that will `fail`.
+ */
+
+export function fail({ request } = {}) {
+  return mock({
+    request,
+    response: {
+      body: {
+        errors: {
+          token: 'is invalid'
+        },
+        success: false
+      },
+      code: 401
+    }
+  });
+}
+
+/**
  * Export a request that will `succeed`.
  */
 


### PR DESCRIPTION
So that it's easier to mock the deprecated authy sandbox environment of allowing 0000000 codes and rejecting all others.