### PR TITLE
add code_length for startPhoneVerification

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ Verify a phone number by sending it a verification code by SMS or call. Custom m
 4. `args.via` _(string)_: the mechanism used to send the verification code (`sms` or `call`).
 5. `[options]` _(Object)_: the options object.
 6. `[options.locale]` _(string)_: the locale of the message received by the user. If none is given, Authy will attempt to auto-detect it based on the country code passed, otherwise English will be used.
+6. `[options.codeLength]` _(integer)_: the number of verification digits sent (by default, 4). Allowed values are 4-10.
 7. `[callback]` _(Function)_: a callback, otherwise a Promise is returned.
 
 ##### Example
@@ -615,7 +616,7 @@ Verify a phone number by sending it a verification code by SMS or call. Custom m
 ```javascript
 import { enums } from 'authy-client';
 
-const response = await client.startPhoneVerification({ countryCode: 'US', locale: 'en', phone: '7754615609', via: enums.verificationVia.SMS });
+const response = await client.startPhoneVerification({ countryCode: 'US', phone: '7754615609', via: enums.verificationVia.SMS });
 
 console.log('Phone information', response);
 ```
@@ -625,7 +626,7 @@ console.log('Phone information', response);
 ```javascript
 const enums = require('authy-client').enums;
 
-client.startPhoneVerification({ countryCode: 'US', locale: 'en', phone: '7754615609', via: enums.verificationVia.SMS })
+client.startPhoneVerification({ countryCode: 'US', phone: '7754615609', via: enums.verificationVia.SMS })
   .then(function(response) {
     console.log('Phone information', response);
   })

--- a/src/client.js
+++ b/src/client.js
@@ -525,9 +525,10 @@ export default class Client {
 
   startPhoneVerification(...args) {
     return Promise.try(() => {
-      const [[{ countryCode: countryOrCallingCode, phone, via } = {}, { locale } = {}], callback] = source(...args);
+      const [[{ countryCode: countryOrCallingCode, phone, via } = {}, { codeLength, locale } = {}], callback] = source(...args);
 
-      validate({ countryCode: countryOrCallingCode, phone, via }, {
+      validate({ codeLength, countryCode: countryOrCallingCode, phone, via }, {
+        codeLength: [is.range(4, 10)],
         countryCode: [is.required(), is.countryOrCallingCode()],
         locale: is.locale(),
         phone: [is.required(), is.phone(countryOrCallingCode)],

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -164,6 +164,28 @@ describe('Client', () => {
       }
     });
 
+    it('should throw an error if `codeLength` is smaller than 4', async () => {
+      try {
+        await client.startPhoneVerification({ countryCode: 'US', locale: 'es', phone: '7754615609', via: verificationVia.SMS }, { codeLength: 3 });
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(ValidationFailedError);
+        e.errors.codeLength[0].show().assert.should.equal('Range');
+      }
+    });
+
+    it('should throw an error if `codeLength` is bigger than 10', async () => {
+      try {
+        await client.startPhoneVerification({ countryCode: 'US', locale: 'es', phone: '7754615609', via: verificationVia.SMS }, { codeLength: 11 });
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(ValidationFailedError);
+        e.errors.codeLength[0].show().assert.should.equal('Range');
+      }
+    });
+
     it('should throw an error if `response` is missing required fields', async () => {
       nock(/authy/).post(/\//).reply(200, { success: true });
 


### PR DESCRIPTION
I'm surprised this wasn't a priority, but for startPhoneVerification a lot of applications use the code length of 6. Here is a patch.

Also, the README was wrong about locale, fixed that.