### PR TITLE
Update yargs@13.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "validator": "^9.2.0",
     "validator.js": "^2.0.3",
     "validator.js-asserts": "^3.0.1",
-    "yargs": "^10.0.3"
+    "yargs": "^13.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
Update this dependency to get rid of `os-locale`, which was requiring a version of `mem` vulnerable to [WS-2018-0236](https://github.com/sindresorhus/mem/issues/14).